### PR TITLE
add assert.date, assert.regexp, assert.uuid (#1). fix #4.

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -9,6 +9,7 @@ var util = require('util');
 ///--- Globals
 
 var NDEBUG = process.env.NODE_NDEBUG || false;
+var UUID_REGEXP = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
 
 
 
@@ -51,6 +52,28 @@ function _assert(arg, type, name, stackFunc) {
                 }
         }
 }
+
+
+function _instanceof(arg, type, name, stackFunc) {
+        if (!NDEBUG) {
+                name = name || type;
+                stackFunc = stackFunc || _instanceof.caller;
+
+                if (!(arg instanceof type)) {
+                        throw new assert.AssertionError({
+                                message: _(TYPE_REQUIRED, name, type.name),
+                                actual: _getClass(arg),
+                                expected: type.name,
+                                operator: 'instanceof',
+                                stackStartFunction: stackFunc
+                        });
+                }
+        }
+}
+
+function _getClass(object) {
+        return (Object.prototype.toString.call(object).slice(8, -1));
+};
 
 
 
@@ -102,6 +125,15 @@ function func(arg, name) {
 
 function number(arg, name) {
         _assert(arg, 'number', name);
+        if (!NDEBUG && (isNaN(arg) || !isFinite(arg))) {
+                throw new assert.AssertionError({
+                        message: _(TYPE_REQUIRED, name, 'number'),
+                        actual: arg,
+                        expected: 'number',
+                        operator: 'isNaN',
+                        stackStartFunction: number
+                });
+        }
 }
 
 
@@ -111,15 +143,16 @@ function object(arg, name) {
 
 
 function stream(arg, name) {
-        if (!(arg instanceof Stream)) {
-                throw new assert.AssertionError({
-                        message: _(TYPE_REQUIRED, name, type),
-                        actual: typeof (arg),
-                        expected: 'Stream',
-                        operator: 'instanceof',
-                        stackStartFunction: buffer
-                });
-        }
+        _instanceof(arg, Stream, name);
+}
+
+
+function date(arg, name) {
+        _instanceof(arg, Date, name);
+}
+
+function regexp(arg, name) {
+        _instanceof(arg, RegExp, name);
 }
 
 
@@ -128,17 +161,33 @@ function string(arg, name) {
 }
 
 
+function uuid(arg, name) {
+        string(arg, name);
+        if (!NDEBUG && !UUID_REGEXP.test(arg)) {
+                throw new assert.AssertionError({
+                        message: _(TYPE_REQUIRED, name, 'uuid'),
+                        actual: 'string',
+                        expected: 'uuid',
+                        operator: 'test',
+                        stackStartFunction: uuid
+                });
+        }
+}
+
 
 ///--- Exports
 
 module.exports = {
         bool: bool,
         buffer: buffer,
+        date: date,
         func: func,
         number: number,
         object: object,
+        regexp: regexp,
         stream: stream,
-        string: string
+        string: string,
+        uuid: uuid
 };
 
 


### PR DESCRIPTION
assert.number(NaN) and assert.number(Infinity) fail now (#4). This breaks backward compatibility.
