### PR TITLE
add tests using tape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   "version": "0.1.5",
   "license": "MIT",
   "main": "./assert.js",
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "4.2.0"
+  },
   "optionalDependencies": {},
+  "scripts": {
+    "test": "./node_modules/.bin/tape tests/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mcavage/node-assert-plus.git"

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -1,0 +1,310 @@
+var f = require('util').format;
+var stream = require('stream');
+
+var test = require('tape');
+
+var assertPlus = require('../');
+
+
+function capitalize(s) {
+	return s[0].toUpperCase() + s.substr(1);
+}
+
+/**
+ * Example JavaScript objects and primitives to test.  The keys of this object
+ * will match the methods exported by the assert-plus module.
+ *
+ * The idea is to check all "valid" examples against their respective methods
+ * and ensure hey do NOT throw, and also check all "invalid" examples
+ * against the same method and ensure that they DO throw.
+ */
+var examples = {
+	bool: {
+		valid: [
+			false,
+			true
+		],
+		invalid: [
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream(),
+			function () {}
+		]
+	},
+	buffer: {
+		valid: [
+			new Buffer(0),
+			new Buffer('foo')
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new stream(),
+			function () {}
+		]
+	},
+	date: {
+		valid: [
+			new Date(),
+			new Date(0)
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Buffer(0),
+			new stream(),
+			function () {}
+		]
+	},
+	func: {
+		valid: [
+			function () {},
+			console.log
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream()
+		]
+	},
+	number: {
+		valid: [
+			-1,
+			0,
+			1,
+			0.5,
+			Math.PI
+		],
+		invalid: [
+			false,
+			true,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream(),
+			function () {}
+		]
+	},
+	object: {
+		valid: [
+			{},
+			console
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/
+		]
+	},
+	regexp: {
+		valid: [
+			/foo/,
+			new RegExp('foo')
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream(),
+			function () {},
+		]
+	},
+	stream: {
+		valid: [
+			new stream(),
+			process.stdout
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			'00000000-0000-0000-0000-000000000000',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			function () {},
+		]
+	},
+	string: {
+		valid: [
+			'foo',
+			'bar',
+			'baz'
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream(),
+			function () {},
+		]
+	},
+	uuid: {
+		valid: [
+			'B3A4A7B5-11C3-449B-B46F-86C57AA99022',
+			'76d26c04-d351-42b7-bba9-c130169cc162'
+		],
+		invalid: [
+			false,
+			true,
+			-1,
+			0,
+			Infinity,
+			NaN,
+			'foo',
+			/regex/,
+			[],
+			{},
+			new Date(),
+			new Buffer(0),
+			new stream(),
+			function () {},
+		]
+	}
+};
+
+test('can continue', function (t) {
+	if (process.env.NODE_NDEBUG)
+		t.fail('NODE_NDEBUG must be unset for this test to work!');
+	t.end();
+});
+
+// loop each example type
+// ie: "func", "bool", "string", etc.
+Object.keys(examples).forEach(function (type) {
+	var capType = capitalize(type);
+
+	test(f('testing type "%s" (valid)', type), function (t) {
+		var validArray = examples[type].valid;
+
+		// test each individual member of the array explicitly
+		validArray.forEach(function (o) {
+			t.doesNotThrow(function () {
+				assertPlus[type](o);
+			}, f('%s(%s) should succeed', type, o));
+
+			t.doesNotThrow(function () {
+				assertPlus['optional' + capType](o);
+			}, f('optional%s(%s) should succeed', capType, o));
+
+			t.doesNotThrow(function () {
+				assertPlus['optional' + capType](undefined);
+			}, f('optional%s(%s) should succeed', capType, 'undefined'));
+		});
+
+		// test the entire array with arrayOf* and optionalArrayOf*
+		t.doesNotThrow(function () {
+			assertPlus['arrayOf' + capType](validArray);
+		}, f('arrayOf%s(%s) should succeed', capType, validArray));
+
+		t.doesNotThrow(function () {
+			assertPlus['optionalArrayOf' + capType](validArray);
+		}, f('optionalArrayOf%s(%s) should succeed', capType, validArray));
+
+		t.doesNotThrow(function () {
+			assertPlus['optionalArrayOf' + capType](undefined);
+		}, f('optionalArrayOf%s(%s should succeed)', capType, 'undefined'));
+
+		t.end();
+	});
+
+	test(f('testing type "%s" (invalid)', type), function (t) {
+		var invalidArray = examples[type].invalid;
+
+		// test each individual member of the array explicitly
+		invalidArray.forEach(function (o) {
+			t.throws(function () {
+				assertPlus[type](o);
+			}, f('%s(%s) should throw', type, o));
+
+			t.throws(function () {
+				assertPlus['optional' + capType](o);
+			}, f('optional%s(%s) should throw', capType, o));
+		});
+
+		// test the entire array with arrayOf* and optionalArrayOf*
+		t.throws(function () {
+			assertPlus['arrayOf' + capType](invalidArray);
+		}, f('arrayOf%s(%s) should throw', capType, invalidArray));
+
+		t.throws(function () {
+			assertPlus['optionalArrayOf' + capType](invalidArray);
+		}, f('optionalArrayOf%s(%s) should throw', capType, invalidArray));
+
+		t.end();
+	});
+});

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -5,7 +5,6 @@ var test = require('tape');
 
 var assertPlus = require('../');
 
-
 function capitalize(s) {
 	return s[0].toUpperCase() + s.substr(1);
 }
@@ -237,9 +236,9 @@ var examples = {
 	}
 };
 
-test('can continue', function (t) {
-	if (process.env.NODE_NDEBUG)
-		t.fail('NODE_NDEBUG must be unset for this test to work!');
+var ndebug = process.env.NODE_NDEBUG;
+test('all.test setup', function (t) {
+	delete process.env.NODE_NDEBUG;
 	t.end();
 });
 
@@ -307,4 +306,9 @@ Object.keys(examples).forEach(function (type) {
 
 		t.end();
 	});
+});
+
+test('all.test teardown', function (t) {
+	process.env.NODE_NDEBUG = ndebug;
+	t.end();
 });

--- a/tests/exports.test.js
+++ b/tests/exports.test.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+
+var test = require('tape');
+
+var assertPlus = require('../');
+
+test('exports', function (t) {
+	t.equal(typeof (assertPlus), 'function');
+
+	t.doesNotThrow(function () {
+		assertPlus(true);
+	}, 'assertPlus(true)');
+
+	t.throws(function () {
+		assertPlus(false);
+	}, 'assertPlus(false)');
+
+	// ensure all exports on "assert" exist on "assert-plus"
+	Object.keys(assert).forEach(function (key) {
+		t.ok(assertPlus[key], 'missing exported property ' + key);
+	});
+
+	t.end();
+});

--- a/tests/ndebug.test.js
+++ b/tests/ndebug.test.js
@@ -1,0 +1,25 @@
+process.env.NODE_NDEBUG = 1;
+
+var f = require('util').format;
+
+var test = require('tape');
+
+var assertPlus = require('../');
+
+test('ndebug', function (t) {
+	// ensure all exports on "assert-plus" that are functions
+	// result in nothing happening
+	Object.keys(assertPlus).forEach(function (key) {
+		if (key === 'AssertionError')
+			return;
+
+		// should not throw because NDEBUG
+		[undefined, null, {}, [], 'foo', 0, NaN].forEach(function (o) {
+			t.doesNotThrow(function() {
+				assertPlus[key](o);
+			}, f('assertPlus.%s(%s)', key, o));
+		});
+	});
+
+	t.end();
+});

--- a/tests/ndebug.test.js
+++ b/tests/ndebug.test.js
@@ -1,10 +1,14 @@
-process.env.NODE_NDEBUG = 1;
-
 var f = require('util').format;
 
 var test = require('tape');
 
 var assertPlus = require('../');
+
+var ndebug = process.env.NODE_NDEBUG;
+test('ndebug.test setup', function (t) {
+	delete process.env.NODE_NDEBUG;
+	t.end();
+});
 
 test('ndebug', function (t) {
 	// ensure all exports on "assert-plus" that are functions
@@ -21,5 +25,10 @@ test('ndebug', function (t) {
 		});
 	});
 
+	t.end();
+});
+
+test('ndebug.test teardown', function (t) {
+	process.env.NODE_NDEBUG = ndebug;
 	t.end();
 });


### PR DESCRIPTION
some tests fail because of bugs that will be addressed in future PRs

```
$ npm test | tail -5
npm ERR! Test failed.  See above for more details.
1..1004
# tests 1004
# pass  721
# fail  283
```