### PR TITLE
node-assert-plus#44 Mozilla Public License in Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle
+	url = https://github.com/TritonDataCenter/jsstyle
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/joyent/javascriptlint
+	url = https://github.com/TritonDataCenter/javascriptlint

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,5 @@
 #
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-
-#
-# Copyright (c) 2018, Joyent, Inc. and assert-plus authors
+# Copyright 2018 Joyent, Inc. and assert-plus authors
 #
 
 NPM = npm


### PR DESCRIPTION
Note: I didn't update the copyright year/org since the only thing being changed is the license header, which is actually a correction and not a change.

This will also not need a version bump or publish to NPM.