### PR TITLE
Modified process.env to be import.meta.env to comply with vite 8ad7ecd

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -209,4 +209,4 @@ function _setExports(ndebug) {
     return out;
 }
 
-module.exports = _setExports(process.env.NODE_NDEBUG);
+module.exports = _setExports(import.meta.env.NODE_NDEBUG);


### PR DESCRIPTION
process.env returns a runtime error when using vite: 

Uncaught ReferenceError: process is not defined
    at node_modules/assert-plus/assert.js (assert.js:211:30)

this is due to vite dropping process.env in https://github.com/vitejs/vite/commit/8ad7ecd1029bdc0b47e55877db10ac630829c7e5. 